### PR TITLE
No change to the root dir of this Vercel project

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
   "private": true,
-  "name": "vercel-require-non-failing-deployment-worktree"
+  "name": "vercel-require-non-failing-deployment-worktree",
+  "description": "A change not affecting the root dir for this Vercel project"
 }


### PR DESCRIPTION
Creates deployment so no need to special case in "require non-failing builds".